### PR TITLE
Return key if translation not found

### DIFF
--- a/src/js/Framework/Locale.js
+++ b/src/js/Framework/Locale.js
@@ -35,9 +35,11 @@ export class Locale {
       this.initialize()
     }
 
-    if (this.data[key] !== null) {
+    if (this.data[key] !== null && this.data[key] !== undefined) {
       return this.data[key]
     }
+
+    return key
   }
 
   act (key) {


### PR DESCRIPTION
If no translation is found for a certain key it is better to return the original key than a NULL value.