### PR TITLE
Add jquery and popper.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,11 @@
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
       "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
+    "jquery": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+    },
     "popper.js": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
@@ -27,8 +32,7 @@
     "sortablejs": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.9.0.tgz",
-      "integrity": "sha512-Ot6bYJ6PoqPmpsqQYXjn1+RKrY2NWQvQt/o4jfd/UYwVWndyO5EPO8YHbnm5HIykf8ENsm4JUrdAvolPT86yYA==",
-      "dev": true
+      "integrity": "sha512-Ot6bYJ6PoqPmpsqQYXjn1+RKrY2NWQvQt/o4jfd/UYwVWndyO5EPO8YHbnm5HIykf8ENsm4JUrdAvolPT86yYA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "bootstrap": "^4.0.0",
     "font-awesome": "^4.7.0",
-    "popper.js": "^1.12.9",
+    "jquery": "^3.4.1",
+    "popper.js": "^1.15.0",
     "select2-theme-bootstrap4": "^0.2.0-beta.2",
     "sortablejs": "^1.9.0"
   }


### PR DESCRIPTION
The package installs bootstrap but it doesn't add the required bootstrap dependencies: jquery en popper.js (this one is not mandatory but it can be handy anyway).