### PR TITLE
Don't need to provide date through an option

### DIFF
--- a/src/js/Framework/DateTimePicker/DatePicker.js
+++ b/src/js/Framework/DateTimePicker/DatePicker.js
@@ -23,7 +23,6 @@ export default class DatePicker {
     };
 
     const input = this._element.find('input');
-    this.options.date = input.val();
   }
 
   init () {


### PR DESCRIPTION
We don't need to provide the date through a option. The plugin can do this by itself.