### PR TITLE
Add clipboard component

### DIFF
--- a/src/js/Framework/Clipboard.js
+++ b/src/js/Framework/Clipboard.js
@@ -1,0 +1,27 @@
+export default class Clipboard {
+  constructor(element)
+  {
+    element.addEventListener('click', (event) => {
+      const elementId = event.currentTarget.getAttribute('data-clipboard-target');
+
+      if (elementId === null) {
+        console.error(
+          'data-clipboard-target attribute was not provided. This is the element we will be copying from.'
+        );
+
+        return;
+      }
+
+      const textSource = document.querySelector(elementId);
+
+      if (textSource === null) {
+        console.error('Source element was not found "' + elementId + '".');
+
+        return;
+      }
+
+      const text = textSource.select();
+      document.execCommand('copy');
+    });
+  }
+}

--- a/src/js/Index.js
+++ b/src/js/Index.js
@@ -20,6 +20,7 @@ import FormCollection from './Framework/FormCollection'
 import DatePicker from './Framework/DateTimePicker/DatePicker'
 import DateTimePicker from './Framework/DateTimePicker/DateTimePicker'
 import TimePicker from './Framework/DateTimePicker/TimePicker'
+import Clipboard from './Framework/Clipboard'
 
 export class Framework {
   constructor () {
@@ -40,7 +41,8 @@ export class Framework {
     Framework.initializeTooltips()
     Framework.initializeSelects()
     Framework.initializeCollections()
-    Framework.initializeDateTimePickers();
+    Framework.initializeDateTimePickers()
+    Framework.initializeClipboard()
   }
 
   static initializeSliders () {
@@ -90,6 +92,12 @@ export class Framework {
 
     $('[data-role="time-picker"]').each((index, element) => {
       new TimePicker(element).init()
+    });
+  }
+
+  static initializeClipboard () {
+    $('[data-role="clipboard"]').each((index, element) => {
+      new Clipboard(element)
     });
   }
 }


### PR DESCRIPTION
This PR adds a new clipboard component. This component can be used to copy text from an input field or textarea to the clipboard.

Example markup:

```
<input id="uniqueLink" type="text" value="This is text to be copied">
<button data-role="clipboard" data-clipboard-target="#uniqueLink" type="button">Copy</button>
```

You need to add `data-role="clipboard"` and `data-clipboard-target="#<elementId>"` for it to work.