### PR TITLE
Trigger events when adding or removing collection elements

### DIFF
--- a/src/js/Framework/FormCollection.js
+++ b/src/js/Framework/FormCollection.js
@@ -29,7 +29,9 @@ export default class FormCollection {
     })
   }
 
-  addItem () {
+  addItem (event) {
+    event.preventDefault();
+
     $(document).trigger('add.collection.item');
 
     const prototype = this._element.data('prototype');
@@ -50,6 +52,8 @@ export default class FormCollection {
   }
 
   removeItem (event) {
+    event.preventDefault();
+
     $(document).trigger('remove.collection.item');
 
     $(event.currentTarget)

--- a/src/js/Framework/FormCollection.js
+++ b/src/js/Framework/FormCollection.js
@@ -29,8 +29,8 @@ export default class FormCollection {
     })
   }
 
-  addItem (event) {
-    event.preventDefault();
+  addItem () {
+    $(document).trigger('add.collection.item');
 
     const prototype = this._element.data('prototype');
     // get the new index
@@ -45,10 +45,12 @@ export default class FormCollection {
 
     // Show add button
     this._element.find('[data-role="collection-add-button"]:last').removeAttr('hidden');
+
+    $(document).trigger('added.collection.item');
   }
 
   removeItem (event) {
-    event.preventDefault();
+    $(document).trigger('remove.collection.item');
 
     $(event.currentTarget)
       .closest('[data-role="collection-item"]')
@@ -59,5 +61,7 @@ export default class FormCollection {
     if (this._element.find('[data-role="collection-item"]').length === 0) {
       this._element.find('[data-role="collection-add-button"]:last').attr('hidden', true);
     }
+
+    $(document).trigger('removed.collection.item');
   }
 }


### PR DESCRIPTION
It's handy to trigger events when adding or removing collection items.
4 new events were added:

* `add.collection.item`
* `added.collection.item`
* `remove.collection.item`
* `removed.collection.item`

You can listen to these event by using for example jQuery like this:

```
$(document).on('added.collection.item', () => {
  // Do something
});
```