### PR TITLE
Add missing select2 dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4296,6 +4296,11 @@
         }
       }
     },
+    "select2": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
+      "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
+    },
     "select2-theme-bootstrap4": {
       "version": "0.2.0-beta.6",
       "resolved": "https://registry.npmjs.org/select2-theme-bootstrap4/-/select2-theme-bootstrap4-0.2.0-beta.6.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "popper.js": "^1.16.1",
     "requestanimationframe": "0.0.23",
     "sass-loader": "^11.1.1",
+    "select2": "^4.0.13",
     "select2-theme-bootstrap4": "^0.2.0-beta.6",
     "sortablejs": "^1.13.0",
     "tempusdominus-bootstrap-4": "^5.39.0",


### PR DESCRIPTION
When setting up a new project, the following error occurs:
```
error  in ./assets/styles/style-dark.scss                                                                                                                                                                                            17:15:18

Module build failed (from ./node_modules/css-loader/dist/cjs.js):
Error: Can't resolve '~select2/dist/css/select2.min.css' in '/Users/jonas/Sites/jonas/reset-test/assets/styles'
```
Because select2 is not installed, but it wants to load it.