### PR TITLE
Fix bootstrap in vue

### DIFF
--- a/src/js/Framework/Components/Toast.vue
+++ b/src/js/Framework/Components/Toast.vue
@@ -50,7 +50,7 @@
     },
     methods: {
       showToast() {
-        const toast = new bootstrap.Toast(this.$el)
+        const toast = new window.bootstrap.Toast(this.$el)
         toast.show()
       },
     },

--- a/src/js/Index.js
+++ b/src/js/Index.js
@@ -3,6 +3,7 @@ import * as bootstrap from 'bootstrap/dist/js/bootstrap.js'
 import Vue from 'vue'
 
 // Vue components
+window.bootstrap = bootstrap
 import Toast from './Framework/Components/Toast'
 
 // Other components


### PR DESCRIPTION
Katrien and me had removed it because it worked in another project without the window.xxx, but it seems it's still necessary for Vue components