### PR TITLE
Select2 only seems to work on a Jquery element

### DIFF
--- a/src/js/Framework/Select.js
+++ b/src/js/Framework/Select.js
@@ -11,7 +11,7 @@ export class Select {
   }
 
   initSelect () {
-    this.element.select2({
+    $(this.element).select2({
       theme: 'bootstrap-5'
     })
   }


### PR DESCRIPTION
The only way I got select2 to work was by changing this.

For future reference: add `import select2 from 'select2'` into imports.js