### PR TITLE
Use the correct BS5 data attributes on toasts

### DIFF
--- a/src/js/Framework/Components/Toast.vue
+++ b/src/js/Framework/Components/Toast.vue
@@ -4,10 +4,10 @@
     :class="'toast-' + type"
     :role="role"
     :aria-live="live"
-    data-animation="true"
+    data-bs-animation="true"
     aria-atomic="true"
-    :data-delay="delay"
-    :data-autohide="autoHideState"
+    :data-bs-delay="delay"
+    :data-bs-autohide="autoHideState"
     :id="id">
     <div class="toast-body">
       <div class="d-flex flex-row">


### PR DESCRIPTION
Fixes autohide not working.

Zie https://getbootstrap.com/docs/5.0/components/toasts/#options