### PR TITLE
Rely on the Dutch i18n offered by Flatpickr instead of manually translating the datepicker widgets

### DIFF
--- a/src/js/Framework/DateTimePicker/DatePicker.js
+++ b/src/js/Framework/DateTimePicker/DatePicker.js
@@ -1,43 +1,10 @@
 import flatpickr from 'flatpickr'
-import Translator from 'bazinga-translator'
+import { Dutch } from 'flatpickr/dist/l10n/nl.js'
 
 export class DatePicker {
   constructor (element) {
-    this.dayNames = [
-      Translator.trans('datepicker.full.days.sunday'), Translator.trans('datepicker.full.days.monday'), Translator.trans('datepicker.full.days.tuesday'),
-      Translator.trans('datepicker.full.days.wednesday'), Translator.trans('datepicker.full.days.thursday'), Translator.trans('datepicker.full.days.friday'),
-      Translator.trans('datepicker.full.days.saturday')
-    ]
-    this.dayNamesShort = [
-      Translator.trans('datepicker.short.days.sunday'), Translator.trans('datepicker.short.days.monday'), Translator.trans('datepicker.short.days.tuesday'),
-      Translator.trans('datepicker.short.days.wednesday'), Translator.trans('datepicker.short.days.thursday'), Translator.trans('datepicker.short.days.friday'),
-      Translator.trans('datepicker.short.days.saturday')
-    ]
-    this.monthNames = [
-      Translator.trans('datepicker.full.months.january'), Translator.trans('datepicker.full.months.february'), Translator.trans('datepicker.full.months.march'),
-      Translator.trans('datepicker.full.months.april'), Translator.trans('datepicker.full.months.may'), Translator.trans('datepicker.full.months.june'),
-      Translator.trans('datepicker.full.months.july'), Translator.trans('datepicker.full.months.august'), Translator.trans('datepicker.full.months.september'),
-      Translator.trans('datepicker.full.months.october'), Translator.trans('datepicker.full.months.november'), Translator.trans('datepicker.full.months.december')
-    ]
-    this.monthNamesShort = [
-      Translator.trans('datepicker.short.months.january'), Translator.trans('datepicker.short.months.february'), Translator.trans('datepicker.short.months.march'),
-      Translator.trans('datepicker.short.months.april'), Translator.trans('datepicker.short.months.may'), Translator.trans('datepicker.short.months.june'),
-      Translator.trans('datepicker.short.months.july'), Translator.trans('datepicker.short.months.august'), Translator.trans('datepicker.short.months.september'),
-      Translator.trans('datepicker.short.months.october'), Translator.trans('datepicker.short.months.november'), Translator.trans('datepicker.short.months.december')
-    ]
-
     this.element = flatpickr(element, {
-      locale: {
-        firstDayOfWeek: 1,
-        weekdays: {
-          shorthand: this.dayNamesShort,
-          longhand: this.dayNames
-        },
-        months: {
-          shorthand: this.monthNamesShort,
-          longhand: this.monthNames
-        }
-      }
+      locale: Dutch
     })
   }
 }

--- a/src/js/Framework/DateTimePicker/TimePicker.js
+++ b/src/js/Framework/DateTimePicker/TimePicker.js
@@ -1,10 +1,12 @@
 import flatpickr from 'flatpickr'
+import { Dutch } from 'flatpickr/dist/l10n/nl.js'
 
 export class TimePicker {
   constructor (element) {
     this.element = flatpickr(element, {
       enableTime: true,
-      noCalendar: true
+      noCalendar: true,
+      locale: Dutch
     })
 
     element.parentNode.querySelector('[data-flatpicker-clear]').addEventListener('click', event => element._flatpickr.clear())


### PR DESCRIPTION
This seemed to be the only use case for the Bazinga JS bundle (which is problematic/broken with Webpack) so might be a good idea to get rid of it altogether after this and look for a different solutions for JS translations?