### PR TITLE
Add the AJAX search tom select component

### DIFF
--- a/src/js/Framework/SelectSearch.js
+++ b/src/js/Framework/SelectSearch.js
@@ -1,0 +1,37 @@
+import TomSelect from 'tom-select'
+
+export default class SelectSearch {
+  constructor (element) {
+    this.element = element
+    this.initializeField()
+  }
+
+  initializeField () {
+    const url = this.element.dataset.route
+
+    this.select = new TomSelect(this.element, {
+      valueField: 'id',
+      shouldLoad: function (query) {
+        return query.length > 3
+      },
+      load: function (query, callback) {
+        const route = url + encodeURIComponent(query)
+        fetch(route)
+          .then(response => response.json())
+          .then(json => {
+            callback(json)
+          }).catch(() => {
+            callback()
+          })
+      },
+      render: {
+        option: function (item, escape) {
+          return '<option>' + escape(item.text) + '</option>'
+        },
+        no_results: function (item, escape) {
+          return '<div class="no-results">Geen resultaten voor "' + escape(item.input) + '"</div>'
+        }
+      }
+    })
+  }
+}

--- a/src/js/Index.js
+++ b/src/js/Index.js
@@ -20,6 +20,7 @@ import { DateTimePicker } from './Framework/DateTimePicker/DateTimePicker'
 import { TimePicker } from './Framework/DateTimePicker/TimePicker'
 import { Clipboard } from './Framework/Clipboard'
 import { Theme } from './Framework/Theme'
+import { SelectSearch } from './Framework/SelectSearch'
 
 window.bootstrap = bootstrap
 
@@ -46,6 +47,10 @@ export class Framework {
       } else {
         element.select = new Select(element)
       }
+    })
+
+    document.querySelectorAll('[data-role="select-search"]').forEach((element) => {
+      element.select = new SelectSearch(element)
     })
   }
 


### PR DESCRIPTION
Basic implementatie van https://tom-select.js.org/examples/remote/. Je zet een `data-route` URL op je form element, triggert die met een data-role die je zelf kiest en dan krijg je een AJAX autocomplete search naar die URL.