### PR TITLE
use 'default' locale when locale is 'en' for flatpicker

### DIFF
--- a/src/js/Framework/DateTimePicker/DatePicker.js
+++ b/src/js/Framework/DateTimePicker/DatePicker.js
@@ -2,7 +2,10 @@ import flatpickr from 'flatpickr'
 
 export class DatePicker {
   constructor (element) {
-    const locale = document.documentElement.lang
+    let locale = document.documentElement.lang
+    if (locale === 'en') {
+      locale = 'default'
+    }
 
     try {
       const i18n = require('flatpickr/dist/l10n/' + locale + '.js').default[locale]


### PR DESCRIPTION
Flatpicker has no 'en' locale -> it's called 'default' instead