### PR TITLE
condition can never be true

### DIFF
--- a/src/js/Framework/FormCollection.js
+++ b/src/js/Framework/FormCollection.js
@@ -27,7 +27,7 @@ export class FormCollection {
       this.element.dataset.index = this.numberOfItems
     }
 
-    if (this.element.dataset.allowDragAndDrop === 1) {
+    if (this.element.dataset.allowDragAndDrop === '1') {
       Sortable.create(this.element.querySelector('ul'), {
         handler: '[data-role="collection-item-change-order"]',
         animation: 150,


### PR DESCRIPTION
Fix for drag and drop functionality:

'this.element.dataset.allowDragAndDrop === 1' can never be true because data attribute is always a string